### PR TITLE
Update main.yml

### DIFF
--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -93,7 +93,7 @@
     namespace: "AWS/EC2"
     statistic: Average
     comparison: "<="
-    threshold: 5
+    threshold: 5.0
     period: 300
     evaluation_periods: 3
     unit: "Percent"


### PR DESCRIPTION
ec2_metric_alarm requires a float now for threshold not a int.
