### PR TITLE
Master branch changes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 - hosts: tag_aws_autoscaling_groupName_autoscale-blog
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - apache

--- a/roles/apache/tasks/Debian.yml
+++ b/roles/apache/tasks/Debian.yml
@@ -2,5 +2,3 @@
   apt: name='{{ item }}' state=present update_cache=yes cache_valid_time=3600
   with_items: packages
   tags: package
-  become: yes
-  become_method: sudo

--- a/roles/apache/tasks/Debian.yml
+++ b/roles/apache/tasks/Debian.yml
@@ -2,3 +2,5 @@
   apt: name='{{ item }}' state=present update_cache=yes cache_valid_time=3600
   with_items: packages
   tags: package
+  become: yes
+  become_method: sudo

--- a/roles/apache/tasks/Debian.yml
+++ b/roles/apache/tasks/Debian.yml
@@ -1,4 +1,4 @@
 - name: install packages (Debian)
-  apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600
+  apt: name='{{ item }}' state=present update_cache=yes cache_valid_time=3600
   with_items: packages
   tags: package

--- a/roles/apache/tasks/RedHat.yml
+++ b/roles/apache/tasks/RedHat.yml
@@ -1,11 +1,7 @@
 - name: stop iptables
   service: name=iptables state=stopped
-  become: yes
-  become_method: sudo
 
 - name: install packages (Red Hat)
   yum: name='{{ item }}' state=present
   with_items: packages
   tags: package
-  become: yes
-  become_method: sudo

--- a/roles/apache/tasks/RedHat.yml
+++ b/roles/apache/tasks/RedHat.yml
@@ -1,7 +1,11 @@
 - name: stop iptables
   service: name=iptables state=stopped
+  become: yes
+  become_method: sudo
 
 - name: install packages (Red Hat)
   yum: name='{{ item }}' state=present
   with_items: packages
   tags: package
+  become: yes
+  become_method: sudo

--- a/roles/apache/tasks/RedHat.yml
+++ b/roles/apache/tasks/RedHat.yml
@@ -2,6 +2,6 @@
   service: name=iptables state=stopped
 
 - name: install packages (Red Hat)
-  yum: name={{ item }} state=present
+  yum: name='{{ item }}' state=present
   with_items: packages
   tags: package

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -13,8 +13,8 @@
   when: ansible_os_family  == "Debian"
 
 - name: copy index.html
-  template: src=index.html.j2 dest={{ apache_docroot }}/index.html
+  template: src=index.html.j2 dest='{{ apache_docroot }}/index.html'
 
 - name: start and enable apache service
-  service: name={{ apache_service }} state=started enabled=yes
+  service: name='{{ apache_service }}' state=started enabled=yes
   tags: service

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -93,7 +93,7 @@
     namespace: "AWS/EC2"
     statistic: Average
     comparison: "<="
-    threshold: 5
+    threshold: 5.0
     period: 300
     evaluation_periods: 3
     unit: "Percent"

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -112,7 +112,7 @@
     metric: CPUUtilization
     namespace: "AWS/EC2"
     statistic: Average
-    comparison: "<="
+    comparison: ">="
     threshold: 90.0
     period: 300
     evaluation_periods: 3

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -42,7 +42,6 @@
     security_groups: "{{ app_security_group.group_id }},{{ tower_callback_client_group_id }},{{ tower_client_group_id }}"
     instance_type: "{{ instance_size }}"
     user_data: "{{ user_data }}"
-    assign_public_ip: true
   tags: launch_config
 
 - name: create autoscale groups

--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -42,6 +42,7 @@
     security_groups: "{{ app_security_group.group_id }},{{ tower_callback_client_group_id }},{{ tower_client_group_id }}"
     instance_type: "{{ instance_size }}"
     user_data: "{{ user_data }}"
+    assign_public_ip: true
   tags: launch_config
 
 - name: create autoscale groups


### PR DESCRIPTION
1.-Use new ansible privilege escalation: become
2.-Use current variable syntax '{{var}}' because {{var}} without quotes is deprecated.
3.-Fixed Scale Up alarm policy, changed <=90 to >=90/
